### PR TITLE
Tiny Fixes

### DIFF
--- a/custom_components/mitsubishi/manifest.json
+++ b/custom_components/mitsubishi/manifest.json
@@ -1,9 +1,10 @@
 {
   "domain": "mitsubishi",
   "name": "Mitsubishi HVAC with Echonet lite",
-  "documentation": "https://github.com/scottyphillips/mitsubishi_echonet",
+  "version": "2.0.0",
+  "documentation": "https://github.com/scottyphillips/mitsubishi_hass",
   "dependencies": [],
   "codeowners": [],
-  "requirements": ["mitsubishi_echonet==0.3.1"],
-  "homeassistant": "0.96.0"
+  "requirements": ["mitsubishi_echonet==0.4.1"],
+  "homeassistant": "0.110.4"
 }

--- a/custom_components/mitsubishi/sensor.py
+++ b/custom_components/mitsubishi/sensor.py
@@ -63,18 +63,17 @@ class MitsubishiClimateSensor(Entity):
     def state(self):
         """Return the state of the sensor."""
 
+        temperature = None
         if self._device_attribute == ATTR_INSIDE_TEMPERATURE:
-            if self._api.roomTemperature == 126:
-               return 'unavailable'
-            else:
-               return self._api.roomTemperature
+            temperature = self._api.roomTemperature
 
         if self._device_attribute == ATTR_OUTSIDE_TEMPERATURE:
-            if self._api.outdoorTemperature == 126:
-               return 'unavailable'
-            else:
-               return self._api.outdoorTemperature
-        return None
+            temperature = self._api.outdoorTemperature
+
+        if temperature is None or temperature == 126:
+            return 'unavailable'
+        else:
+            return temperature
 
     @property
     def unit_of_measurement(self):

--- a/custom_components/mitsubishi/sensor.py
+++ b/custom_components/mitsubishi/sensor.py
@@ -86,7 +86,7 @@ class MitsubishiClimateSensor(Entity):
             self._api.update()
             self._api.getOutdoorTemperature()
         except KeyError:
-           _LOGGER.warning("HA requested an update from HVAC %s but no data was received", self._api.netif)
+            _LOGGER.warning("HA requested an update from HVAC %s but no data was received", self._api.netif)
 
     # @property
     # def device_info(self):


### PR DESCRIPTION
- Update manifest.json
  - The `version` key is mandatory at this moment. I got `WARNING (MainThread) [homeassistant.loader] No 'version' key in the manifest file for custom integration 'mitsubishi'. This will not be allowed in a future version of Home Assistant. Please report this to the maintainer of 'mitsubishi'`.
 - Increase interoperability of temperature measurements
   - `roomTemperature` and `outdoorTemperature` could be `None` at Daikin platform. I've tried to improve this exception handling while maintaining compatibility with Mitsubishi.