### PR TITLE
Add version to manifest (required since HA 2021.3)

### DIFF
--- a/custom_components/mitsubishi/manifest.json
+++ b/custom_components/mitsubishi/manifest.json
@@ -5,5 +5,6 @@
   "dependencies": [],
   "codeowners": [],
   "requirements": ["mitsubishi_echonet==0.3.1"],
-  "homeassistant": "0.96.0"
+  "homeassistant": "0.96.0",
+  "version": "2021.3.1"
 }


### PR DESCRIPTION
As per https://www.home-assistant.io/blog/2021/03/03/release-20213/#breaking-changes