### PR TITLE
Set the `unique_id` attribute

### DIFF
--- a/custom_components/mitsubishi/climate.py
+++ b/custom_components/mitsubishi/climate.py
@@ -144,6 +144,11 @@ class MitsubishiClimate(ClimateEntity):
         return self._name
 
     @property
+    def unique_id(self):
+        """Return a unique ID."""
+        return self._api.getIdentificationNumber()["identification_number"]
+
+    @property
     def temperature_unit(self):
         """Return the unit of measurement."""
         return self._unit_of_measurement

--- a/custom_components/mitsubishi/sensor.py
+++ b/custom_components/mitsubishi/sensor.py
@@ -43,11 +43,6 @@ class MitsubishiClimateSensor(Entity):
         if self._sensor[CONF_TYPE] == SENSOR_TYPE_TEMPERATURE:
             self._unit_of_measurement = units.temperature_unit
 
-    # @property
-    # def unique_id(self):
-    #    """Return a unique ID."""
-    #    return f"{self._api.mac}-{self._device_attribute}"
-
     @property
     def icon(self):
         """Icon to use in the frontend, if any."""
@@ -57,6 +52,11 @@ class MitsubishiClimateSensor(Entity):
     def name(self):
         """Return the name of the sensor."""
         return self._name
+
+    @property
+    def unique_id(self):
+        """Return a unique ID."""
+        return f"{self._api.getIdentificationNumber()["identification_number"]}-{self._device_attribute}"
 
     @property
     def state(self):


### PR DESCRIPTION
https://github.com/scottyphillips/mitsubishi_echonet/commit/f1fdee2e697cc5ec5a984fa00d76dff5676a9dcc provides a unique identification for each devices. 

Now we can set the [`unique_id` attribute](https://developers.home-assistant.io/docs/core/entity#generic-properties) in the entities. With that, changing various parameters through not only YAML but the web interface could be possible (see: [This entity does not have a unique ID?](https://www.home-assistant.io/faq/unique_id/)).