### PR TITLE
Stop concurrent requests to the same device and allow users so specify desired sensors

### DIFF
--- a/custom_components/mitsubishi/const.py
+++ b/custom_components/mitsubishi/const.py
@@ -20,4 +20,9 @@ SENSOR_TYPES = {
         CONF_ICON: "mdi:thermometer",
         CONF_TYPE: SENSOR_TYPE_TEMPERATURE,
     },
+    ATTR_TARGET_TEMPERATURE: {
+        CONF_NAME: "Target Temperature",
+        CONF_ICON: "mdi:thermometer",
+        CONF_TYPE: SENSOR_TYPE_TEMPERATURE,
+    },
 }

--- a/custom_components/mitsubishi/manifest.json
+++ b/custom_components/mitsubishi/manifest.json
@@ -6,5 +6,5 @@
   "codeowners": [],
   "requirements": ["mitsubishi_echonet==0.5.1"],
   "homeassistant": "0.96.0",
-  "version": "2.1.4"
+  "version": "2.2.0"
 }


### PR DESCRIPTION
Set PARALLEL_UPDATES = 1 to stop climate and sensor devices querying the same device at the same time

Climate Platform
* Added outside temperature into an extra state attribute so it can be used in template sensors
* Turn on/turn off now also use hass.async_add_executor_job()
* Added additional debug level logging level
* Tidied up some comments / commented out code

Sensor Platform:
* Add the ability to have a target temperature sensor
* The desired sensors types can now be (optionally) configured in yaml
* Changed the name to use the monitored state configuration name to fix capitalization
* Added additional debug level logging level
* Tidied up some comments / commented out code

Updated version to 2.2.0
Updated documentation in relation to these changes